### PR TITLE
add -ldflags flag and pass it to "go install"

### DIFF
--- a/bin.go
+++ b/bin.go
@@ -229,34 +229,42 @@ func Source(b []Bin, gopath string) error {
 	return cmd.Run()
 }
 
+// UpdateOpts holds the options for Update.
+type UpdateOpts struct {
+	Bins  []Bin
+	Log   func(*Bin, time.Duration, error)
+	Flags []string
+}
+
 // Update checks out repositories for each Go executable in b slice in a temporary
 // directory, builds new executable and replaces it with the old one.
 // The update is performed on multiple goroutines. Setting GOMAXPROCS may speed
 // up this function.
-func Update(b []Bin, log func(*Bin, time.Duration, error), installFlags ...string) {
+func Update(opts UpdateOpts) {
 	type kv struct {
 		k string
 		v []string
 	}
-	var (
-		builds = make(map[string][]string, len(b))
-		mtx    sync.Mutex // protects b
-		seterr = func(t time.Time, err error, paths ...string) {
-			mtx.Lock()
-			for _, path := range paths {
-				for i := range b {
-					if b[i].Path == path {
-						log(&b[i], time.Now().Sub(t), err)
-						b[i].err = err
-					}
+	var mtx sync.Mutex // protects b
+	b := opts.Bins
+
+	builds := make(map[string][]string, len(b))
+	seterr := func(t time.Time, err error, paths ...string) {
+		mtx.Lock()
+		for _, path := range paths {
+			for i := range b {
+				if b[i].Path == path {
+					opts.Log(&b[i], time.Now().Sub(t), err)
+					b[i].err = err
 				}
 			}
-			mtx.Unlock()
 		}
-		fmterr = func(err error, p []byte) error {
-			return fmt.Errorf("%v\n\t%s", err, bytes.Replace(p, []byte{'\n'}, []byte("\n\t"), -1))
-		}
-	)
+		mtx.Unlock()
+	}
+	fmterr := func(err error, p []byte) error {
+		return fmt.Errorf("%v\n\t%s", err, bytes.Replace(p, []byte{'\n'}, []byte("\n\t"), -1))
+	}
+
 	for i := range b {
 		if b[i].CanWrite {
 			if v, ok := builds[b[i].Package]; ok {
@@ -299,9 +307,9 @@ func Update(b []Bin, log func(*Bin, time.Duration, error), installFlags ...strin
 					continue
 				}
 				args := append(append(append(
-					make([]string, 0, 2+len(installFlags)),
+					make([]string, 0, 2+len(opts.Flags)),
 					"install"),
-					installFlags...),
+					opts.Flags...),
 					kv.k)
 				install := exec.Command("go", args...)
 				install.Env = env

--- a/bin.go
+++ b/bin.go
@@ -233,7 +233,7 @@ func Source(b []Bin, gopath string) error {
 // directory, builds new executable and replaces it with the old one.
 // The update is performed on multiple goroutines. Setting GOMAXPROCS may speed
 // up this function.
-func Update(b []Bin, log func(*Bin, time.Duration, error)) {
+func Update(b []Bin, log func(*Bin, time.Duration, error), installFlags ...string) {
 	type kv struct {
 		k string
 		v []string
@@ -298,7 +298,12 @@ func Update(b []Bin, log func(*Bin, time.Duration, error)) {
 					fail(fmterr(err, p), kv.v...)
 					continue
 				}
-				install := exec.Command("go", "install", kv.k)
+				args := append(append(append(
+					make([]string, 0, 2+len(installFlags)),
+					"install"),
+					installFlags...),
+					kv.k)
+				install := exec.Command("go", args...)
 				install.Env = env
 				if p, err := install.CombinedOutput(); err != nil {
 					fail(fmterr(err, p), kv.v...)

--- a/cmd/gobin/main.go
+++ b/cmd/gobin/main.go
@@ -20,13 +20,13 @@
 //   code.google.com/p/go.tools/cmd/godoc
 //   ~ $ tree -L 3 /tmp/gopath/src/
 //   /tmp/gopath/src/
-//   âââ code.google.com
-//   âÂ Â  âââ p
-//   âÂ Â      âââ go.tools
-//   âââ github.com
-//       âââ rjeczalik
-//           âââ tools
-//           âââ which
+//   ├── code.google.com
+//   │   └── p
+//   │       └── go.tools
+//   └── github.com
+//       └── rjeczalik
+//           ├── tools
+//           └── which
 //
 //   7 directories, 0 files
 //

--- a/cmd/gobin/main.go
+++ b/cmd/gobin/main.go
@@ -185,7 +185,7 @@ func main() {
 		if ldflags != "" {
 			installFlags = append(installFlags, "-ldflags="+ldflags)
 		}
-		bin.Update(b, log, installFlags...)
+		bin.Update(bin.UpdateOpts{Bins: b, Log: log, Flags: installFlags})
 	case source != "":
 		if source == "." {
 			source = os.Getenv("GOPATH")

--- a/cmd/gobin/main.go
+++ b/cmd/gobin/main.go
@@ -20,13 +20,13 @@
 //   code.google.com/p/go.tools/cmd/godoc
 //   ~ $ tree -L 3 /tmp/gopath/src/
 //   /tmp/gopath/src/
-//   ├── code.google.com
-//   │   └── p
-//   │       └── go.tools
-//   └── github.com
-//       └── rjeczalik
-//           ├── tools
-//           └── which
+//   âââ code.google.com
+//   âÂ Â  âââ p
+//   âÂ Â      âââ go.tools
+//   âââ github.com
+//       âââ rjeczalik
+//           âââ tools
+//           âââ which
 //
 //   7 directories, 0 files
 //
@@ -61,9 +61,10 @@
 //       gobin [-u] [-s=.|gopath] [path|package...]
 //
 //   FLAGS:
-//       -u        Updates Go binaries
-//       -s <dir>  Go-gets sources for Go specified binaries into <dir> $GOPATH
-//                 (use '.' for current $GOPATH)
+//       -u                Updates Go binaries
+//       -s <dir>          Go-gets sources for Go specified binaries into <dir> $GOPATH
+//                         (use '.' for current $GOPATH)
+//       -ldflags=<flags>  passes "-ldflags=flags" to "go install"
 //
 //   EXAMPLES:
 //       gobin                    Lists all Go binaries (looks up $PATH/$GOBIN/$GOPATH)
@@ -101,9 +102,10 @@ USAGE:
 	gobin [-u] [-s=.|gopath] [path|package...]
 
 FLAGS:
-	-u        Updates Go binaries
-	-s <dir>  Go-gets sources for Go specified binaries into <dir> $GOPATH
-	          (use '.' for current $GOPATH)
+	-u                Updates Go binaries
+	-s <dir>          Go-gets sources for Go specified binaries into <dir> $GOPATH
+	                  (use '.' for current $GOPATH)
+	-ldflags=<flags>  passes "-ldflags=flags" to "go install"
 
 EXAMPLES:
 	gobin                    Lists all Go binaries (looks up $PATH/$GOBIN/$GOPATH)
@@ -113,11 +115,12 @@ EXAMPLES:
 	                         on system into new /var/mirror $GOPATH
 	gobin -u                 Updates all Go binaries in-place
 	gobin -u github.com      Updates all Go binaries installed from github.com
-	gobin ~/bin              Lists all Go binaries from the ~/bin directory`
+	gobin ~/bin              Lists all Go binaries from the ~/bin directory
+	gobin -u -ldflags='-w -s'	Updates all go binaries in-place, using "go install -ldflags='-w -s'"`
 
 var (
-	source string
-	update bool
+	source, ldflags string
+	update          bool
 )
 
 func ishelp(s string) bool {
@@ -128,6 +131,7 @@ func parse() []string {
 	flag.Usage = func() { die(usage) }
 	flag.StringVar(&source, "s", "", "")
 	flag.BoolVar(&update, "u", false, "")
+	flag.StringVar(&ldflags, "ldflags", "", "")
 	flag.Parse()
 	return flag.Args()
 }
@@ -167,6 +171,7 @@ func main() {
 	if e != nil {
 		die(e)
 	}
+	var installFlags []string
 	switch {
 	case update:
 		if self := self(); self != "" {
@@ -177,7 +182,10 @@ func main() {
 				}
 			}
 		}
-		bin.Update(b, log)
+		if ldflags != "" {
+			installFlags = append(installFlags, "-ldflags="+ldflags)
+		}
+		bin.Update(b, log, installFlags...)
 	case source != "":
 		if source == "." {
 			source = os.Getenv("GOPATH")


### PR DESCRIPTION
To shrink binaries, I invoke `go install -ldflags='-w -s'`.
This patch allows gobin to do the same.